### PR TITLE
Fix truncated sentence in architecture doc

### DIFF
--- a/Multi-Agent Thinking System Architecture Design.md
+++ b/Multi-Agent Thinking System Architecture Design.md
@@ -72,5 +72,5 @@ To observe the agents' thinking process and conversations, a monitoring interfac
 ## 5. Future Considerations
 
 *   **Persistent Memory:** Implementing a more sophisticated memory system for the AI to retain long-term learnings and context across sessions.
-*   **Goal-Oriented Dreaming:** While the initial goal is 
+*   **Goal-Oriented Dreaming:** While the initial goal is to facilitate open-ended, curiosity-driven conversation, future iterations may experiment with optional objectives that guide the agents toward collaborative tasks.
 


### PR DESCRIPTION
## Summary
- complete the `Goal-Oriented Dreaming` bullet in architecture doc

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885c39a1b7c832a855a533f04f40702